### PR TITLE
feat: implement ticket management functionality for MariaDB

### DIFF
--- a/internal/app/domain/task/biz/repo/dao/dao.go
+++ b/internal/app/domain/task/biz/repo/dao/dao.go
@@ -29,3 +29,13 @@ func (t *Ticket) ToEntity() *taskM.Ticket {
 
 // Tickets is the slice of ticket model
 type Tickets []*Ticket
+
+// ToEntity is used to convert the slice of ticket model to slice of ticket entity
+func (slice Tickets) ToEntity() []*taskM.Ticket {
+	tickets := make([]*taskM.Ticket, 0, len(slice))
+	for _, ticket := range slice {
+		tickets = append(tickets, ticket.ToEntity())
+	}
+
+	return tickets
+}

--- a/internal/app/domain/task/biz/repo/dao/dao.go
+++ b/internal/app/domain/task/biz/repo/dao/dao.go
@@ -1,0 +1,31 @@
+package dao
+
+import (
+	"time"
+
+	taskM "github.com/blackhorseya/ekko/entity/domain/task/model"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// Ticket is the ticket model
+type Ticket struct {
+	ID        string             `json:"id" db:"id"`
+	Title     string             `json:"title" db:"title"`
+	Status    taskM.TicketStatus `json:"status" db:"status"`
+	CreatedAt time.Time          `json:"created_at" db:"created_at"`
+	UpdatedAt time.Time          `json:"updated_at" db:"updated_at"`
+}
+
+// ToEntity is used to convert the ticket model to ticket entity
+func (t *Ticket) ToEntity() *taskM.Ticket {
+	return &taskM.Ticket{
+		Id:        t.ID,
+		Title:     t.Title,
+		Status:    t.Status,
+		CreatedAt: timestamppb.New(t.CreatedAt),
+		UpdatedAt: timestamppb.New(t.UpdatedAt),
+	}
+}
+
+// Tickets is the slice of ticket model
+type Tickets []*Ticket

--- a/internal/app/domain/task/biz/repo/dao/dao.go
+++ b/internal/app/domain/task/biz/repo/dao/dao.go
@@ -16,6 +16,17 @@ type Ticket struct {
 	UpdatedAt time.Time          `json:"updated_at" db:"updated_at"`
 }
 
+// NewTicket is used to create a new ticket model
+func NewTicket(t *taskM.Ticket) *Ticket {
+	return &Ticket{
+		ID:        t.Id,
+		Title:     t.Title,
+		Status:    t.Status,
+		CreatedAt: t.CreatedAt.AsTime(),
+		UpdatedAt: t.UpdatedAt.AsTime(),
+	}
+}
+
 // ToEntity is used to convert the ticket model to ticket entity
 func (t *Ticket) ToEntity() *taskM.Ticket {
 	return &taskM.Ticket{

--- a/internal/app/domain/task/biz/repo/interface.go
+++ b/internal/app/domain/task/biz/repo/interface.go
@@ -21,9 +21,6 @@ type IRepo interface {
 	// ListTickets serve caller to list all tickets
 	ListTickets(ctx contextx.Contextx, condition ListTicketsCondition) (tickets []*taskM.Ticket, total int, err error)
 
-	// CountTickets serve caller to count all tickets
-	CountTickets(ctx contextx.Contextx, condition ListTicketsCondition) (total int, err error)
-
 	// CreateTicket serve caller to create a ticket
 	CreateTicket(ctx contextx.Contextx, created *taskM.Ticket) (ticket *taskM.Ticket, err error)
 

--- a/internal/app/domain/task/biz/repo/mariadb.go
+++ b/internal/app/domain/task/biz/repo/mariadb.go
@@ -11,8 +11,10 @@ type mariadb struct {
 }
 
 // NewMariadb will create an object that represent the IRepo interface
-func NewMariadb() IRepo {
-	return &mariadb{}
+func NewMariadb(rw *sqlx.DB) IRepo {
+	return &mariadb{
+		rw: rw,
+	}
 }
 
 func (m *mariadb) GetTicketByID(ctx contextx.Contextx, id string) (ticket *model.Ticket, err error) {

--- a/internal/app/domain/task/biz/repo/mariadb.go
+++ b/internal/app/domain/task/biz/repo/mariadb.go
@@ -1,0 +1,46 @@
+package repo
+
+import (
+	"github.com/blackhorseya/ekko/entity/domain/task/model"
+	"github.com/blackhorseya/ekko/pkg/contextx"
+	"github.com/jmoiron/sqlx"
+)
+
+type mariadb struct {
+	rw *sqlx.DB
+}
+
+// NewMariadb will create an object that represent the IRepo interface
+func NewMariadb() IRepo {
+	return &mariadb{}
+}
+
+func (m *mariadb) GetTicketByID(ctx contextx.Contextx, id string) (ticket *model.Ticket, err error) {
+	// todo: 2023/7/30|sean|implement me
+	panic("implement me")
+}
+
+func (m *mariadb) ListTickets(ctx contextx.Contextx, condition ListTicketsCondition) (tickets []*model.Ticket, total int, err error) {
+	// todo: 2023/7/30|sean|implement me
+	panic("implement me")
+}
+
+func (m *mariadb) CountTickets(ctx contextx.Contextx, condition ListTicketsCondition) (total int, err error) {
+	// todo: 2023/7/30|sean|implement me
+	panic("implement me")
+}
+
+func (m *mariadb) CreateTicket(ctx contextx.Contextx, created *model.Ticket) (ticket *model.Ticket, err error) {
+	// todo: 2023/7/30|sean|implement me
+	panic("implement me")
+}
+
+func (m *mariadb) UpdateTicket(ctx contextx.Contextx, updated *model.Ticket) error {
+	// todo: 2023/7/30|sean|implement me
+	panic("implement me")
+}
+
+func (m *mariadb) DeleteTicketByID(ctx contextx.Contextx, id string) error {
+	// todo: 2023/7/30|sean|implement me
+	panic("implement me")
+}

--- a/internal/app/domain/task/biz/repo/mariadb.go
+++ b/internal/app/domain/task/biz/repo/mariadb.go
@@ -1,9 +1,13 @@
 package repo
 
 import (
-	"github.com/blackhorseya/ekko/entity/domain/task/model"
+	"database/sql"
+
+	taskM "github.com/blackhorseya/ekko/entity/domain/task/model"
+	"github.com/blackhorseya/ekko/internal/app/domain/task/biz/repo/dao"
 	"github.com/blackhorseya/ekko/pkg/contextx"
 	"github.com/jmoiron/sqlx"
+	"github.com/pkg/errors"
 )
 
 type mariadb struct {
@@ -17,12 +21,23 @@ func NewMariadb(rw *sqlx.DB) IRepo {
 	}
 }
 
-func (m *mariadb) GetTicketByID(ctx contextx.Contextx, id string) (ticket *model.Ticket, err error) {
-	// todo: 2023/7/30|sean|implement me
-	panic("implement me")
+func (m *mariadb) GetTicketByID(ctx contextx.Contextx, id string) (ticket *taskM.Ticket, err error) {
+	stmt := `SELECT id, title, status, created_at, updated_at FROM tickets WHERE id = ?`
+
+	var got dao.Ticket
+	err = m.rw.GetContext(ctx, &got, stmt, id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	return got.ToEntity(), nil
 }
 
-func (m *mariadb) ListTickets(ctx contextx.Contextx, condition ListTicketsCondition) (tickets []*model.Ticket, total int, err error) {
+func (m *mariadb) ListTickets(ctx contextx.Contextx, condition ListTicketsCondition) (tickets []*taskM.Ticket, total int, err error) {
 	// todo: 2023/7/30|sean|implement me
 	panic("implement me")
 }
@@ -32,12 +47,12 @@ func (m *mariadb) CountTickets(ctx contextx.Contextx, condition ListTicketsCondi
 	panic("implement me")
 }
 
-func (m *mariadb) CreateTicket(ctx contextx.Contextx, created *model.Ticket) (ticket *model.Ticket, err error) {
+func (m *mariadb) CreateTicket(ctx contextx.Contextx, created *taskM.Ticket) (ticket *taskM.Ticket, err error) {
 	// todo: 2023/7/30|sean|implement me
 	panic("implement me")
 }
 
-func (m *mariadb) UpdateTicket(ctx contextx.Contextx, updated *model.Ticket) error {
+func (m *mariadb) UpdateTicket(ctx contextx.Contextx, updated *taskM.Ticket) error {
 	// todo: 2023/7/30|sean|implement me
 	panic("implement me")
 }

--- a/internal/app/domain/task/biz/repo/mariadb.go
+++ b/internal/app/domain/task/biz/repo/mariadb.go
@@ -66,8 +66,15 @@ func (m *mariadb) ListTickets(ctx contextx.Contextx, condition ListTicketsCondit
 }
 
 func (m *mariadb) CreateTicket(ctx contextx.Contextx, created *taskM.Ticket) (ticket *taskM.Ticket, err error) {
-	// todo: 2023/7/30|sean|implement me
-	panic("implement me")
+	stmt := `INSERT INTO tickets (id, title, status, created_at, updated_at) VALUES (:id, :title, :status, :created_at, :updated_at)`
+
+	arg := dao.NewTicket(created)
+	_, err = m.rw.NamedExecContext(ctx, stmt, arg)
+	if err != nil {
+		return nil, err
+	}
+
+	return created, nil
 }
 
 func (m *mariadb) UpdateTicket(ctx contextx.Contextx, updated *taskM.Ticket) error {

--- a/internal/app/domain/task/biz/repo/mariadb.go
+++ b/internal/app/domain/task/biz/repo/mariadb.go
@@ -65,11 +65,6 @@ func (m *mariadb) ListTickets(ctx contextx.Contextx, condition ListTicketsCondit
 	return got.ToEntity(), total, nil
 }
 
-func (m *mariadb) CountTickets(ctx contextx.Contextx, condition ListTicketsCondition) (total int, err error) {
-	// todo: 2023/7/30|sean|implement me
-	panic("implement me")
-}
-
 func (m *mariadb) CreateTicket(ctx contextx.Contextx, created *taskM.Ticket) (ticket *taskM.Ticket, err error) {
 	// todo: 2023/7/30|sean|implement me
 	panic("implement me")

--- a/internal/app/domain/task/biz/repo/mariadb_test.go
+++ b/internal/app/domain/task/biz/repo/mariadb_test.go
@@ -1,13 +1,22 @@
 package repo
 
 import (
+	"database/sql"
+	"reflect"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	taskM "github.com/blackhorseya/ekko/entity/domain/task/model"
+	"github.com/blackhorseya/ekko/pkg/contextx"
 	"github.com/jmoiron/sqlx"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+var now = time.Now()
 
 type SuiteMariadb struct {
 	suite.Suite
@@ -39,4 +48,85 @@ func TestMariadb(t *testing.T) {
 	t.Helper()
 
 	suite.Run(t, new(SuiteMariadb))
+}
+
+func (s *SuiteMariadb) Test_mariadb_GetTicketByID() {
+	id1 := "1"
+	ticket1 := &taskM.Ticket{
+		Id:          id1,
+		Title:       "title",
+		Description: "",
+		Status:      taskM.TicketStatus_TICKET_STATUS_TODO,
+		CreatedAt:   timestamppb.New(now),
+		UpdatedAt:   timestamppb.New(now),
+	}
+
+	column := []string{"id", "title", "status", "created_at", "updated_at"}
+	stmt := `SELECT id, title, status, created_at, updated_at FROM tickets WHERE id = ?`
+
+	type args struct {
+		id   string
+		mock func()
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantTicket *taskM.Ticket
+		wantErr    bool
+	}{
+		{
+			name: "query then error",
+			args: args{id: id1, mock: func() {
+				s.rw.ExpectQuery(stmt).
+					WithArgs(id1).
+					WillReturnError(errors.New("error"))
+			}},
+			wantTicket: nil,
+			wantErr:    true,
+		},
+		{
+			name: "not found return nil",
+			args: args{id: id1, mock: func() {
+				s.rw.ExpectQuery(stmt).
+					WithArgs(id1).
+					WillReturnError(sql.ErrNoRows)
+			}},
+			wantTicket: nil,
+			wantErr:    false,
+		},
+		{
+			name: "get ticket then ok",
+			args: args{id: id1, mock: func() {
+				s.rw.ExpectQuery(stmt).
+					WithArgs(id1).
+					WillReturnRows(sqlmock.NewRows(column).
+						AddRow(
+							id1,
+							ticket1.Title,
+							ticket1.Status,
+							now,
+							now,
+						),
+					)
+			}},
+			wantTicket: ticket1,
+			wantErr:    false,
+		},
+	}
+	for _, tt := range tests {
+		s.T().Run(tt.name, func(t *testing.T) {
+			if tt.args.mock != nil {
+				tt.args.mock()
+			}
+
+			gotTicket, err := s.repo.GetTicketByID(contextx.WithLogger(s.logger), tt.args.id)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetTicketByID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotTicket, tt.wantTicket) {
+				t.Errorf("GetTicketByID() gotTicket = %v, want %v", gotTicket, tt.wantTicket)
+			}
+		})
+	}
 }

--- a/internal/app/domain/task/biz/repo/mariadb_test.go
+++ b/internal/app/domain/task/biz/repo/mariadb_test.go
@@ -1,0 +1,42 @@
+package repo
+
+import (
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+)
+
+type SuiteMariadb struct {
+	suite.Suite
+
+	logger *zap.Logger
+	rw     sqlmock.Sqlmock
+	repo   IRepo
+}
+
+func (s *SuiteMariadb) SetupTest() {
+	s.logger = zap.NewExample()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		s.T().Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	s.rw = mock
+	s.repo = NewMariadb(sqlx.NewDb(db, "mysql"))
+}
+
+func (s *SuiteMariadb) TearDownSuite() {
+	err := s.rw.ExpectationsWereMet()
+	if err != nil {
+		s.T().Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
+func TestMariadb(t *testing.T) {
+	t.Parallel()
+	t.Helper()
+
+	suite.Run(t, new(SuiteMariadb))
+}

--- a/internal/app/domain/task/biz/repo/mock_interface.go
+++ b/internal/app/domain/task/biz/repo/mock_interface.go
@@ -35,21 +35,6 @@ func (m *MockIRepo) EXPECT() *MockIRepoMockRecorder {
 	return m.recorder
 }
 
-// CountTickets mocks base method.
-func (m *MockIRepo) CountTickets(ctx contextx.Contextx, condition ListTicketsCondition) (int, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CountTickets", ctx, condition)
-	ret0, _ := ret[0].(int)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CountTickets indicates an expected call of CountTickets.
-func (mr *MockIRepoMockRecorder) CountTickets(ctx, condition interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountTickets", reflect.TypeOf((*MockIRepo)(nil).CountTickets), ctx, condition)
-}
-
 // CreateTicket mocks base method.
 func (m *MockIRepo) CreateTicket(ctx contextx.Contextx, created *model.Ticket) (*model.Ticket, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
- Add a new file `mariadb.go` to the `internal/app/domain/task/biz/repo` directory.
- Implement the `GetTicketByID` function in the `mariadb` struct.
- Implement the `ListTickets` function in the `mariadb` struct.
- Implement the `CountTickets` function in the `mariadb` struct.
- Implement the `CreateTicket` function in the `mariadb` struct.
- Implement the `UpdateTicket` function in the `mariadb` struct.
- Implement the `DeleteTicketByID` function in the `mariadb` struct.