### PR TITLE
feat: refactor ticket update functionality and add tests

### DIFF
--- a/internal/app/domain/task/biz/repo/mariadb.go
+++ b/internal/app/domain/task/biz/repo/mariadb.go
@@ -78,8 +78,15 @@ func (m *mariadb) CreateTicket(ctx contextx.Contextx, created *taskM.Ticket) (ti
 }
 
 func (m *mariadb) UpdateTicket(ctx contextx.Contextx, updated *taskM.Ticket) error {
-	// todo: 2023/7/30|sean|implement me
-	panic("implement me")
+	stmt := `UPDATE tickets SET title = :title, status = :status, updated_at = :updated_at WHERE id = :id`
+
+	arg := dao.NewTicket(updated)
+	_, err := m.rw.NamedExecContext(ctx, stmt, arg)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (m *mariadb) DeleteTicketByID(ctx contextx.Contextx, id string) error {

--- a/internal/app/domain/task/biz/repo/mariadb.go
+++ b/internal/app/domain/task/biz/repo/mariadb.go
@@ -90,6 +90,12 @@ func (m *mariadb) UpdateTicket(ctx contextx.Contextx, updated *taskM.Ticket) err
 }
 
 func (m *mariadb) DeleteTicketByID(ctx contextx.Contextx, id string) error {
-	// todo: 2023/7/30|sean|implement me
-	panic("implement me")
+	stmt := `DELETE FROM tickets WHERE id = ?`
+
+	_, err := m.rw.ExecContext(ctx, stmt, id)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
- Update the `CreateTicket` function in `mariadb.go` to use a prepared statement for updating the tickets table.
- Implement the `UpdateTicket` function in `mariadb.go` to update the title, status, and updated_at fields of a ticket in the tickets table.
- Implement tests for the `UpdateTicket` function in `mariadb_test.go` to test the behavior of updating a ticket in the database.