### PR TITLE
refactor: refactor CLI adapter code

### DIFF
--- a/adapter/cli/app/cmd.go
+++ b/adapter/cli/app/cmd.go
@@ -8,7 +8,6 @@ import (
 )
 
 type cmd struct {
-	path    string
 	rootCmd *cobra.Command
 }
 
@@ -26,7 +25,6 @@ func NewCmd() adapters.CLI {
 	rootCmd.AddCommand(config.NewConfigCmd())
 
 	return &cmd{
-		path:    path,
 		rootCmd: rootCmd,
 	}
 }

--- a/adapter/cli/app/cmd.go
+++ b/adapter/cli/app/cmd.go
@@ -8,6 +8,7 @@ import (
 )
 
 type cmd struct {
+	path    string
 	rootCmd *cobra.Command
 }
 
@@ -18,10 +19,14 @@ func NewCmd() adapters.CLI {
 		SilenceUsage: true,
 	}
 
+	var path string
+	rootCmd.PersistentFlags().StringVarP(&path, "config", "f", "", "path to config file (default: $HOME/.ekko/config.yaml)")
+
 	rootCmd.AddCommand(version.NewVersionCmd())
 	rootCmd.AddCommand(config.NewConfigCmd())
 
 	return &cmd{
+		path:    path,
 		rootCmd: rootCmd,
 	}
 }

--- a/adapter/cli/app/cmd.go
+++ b/adapter/cli/app/cmd.go
@@ -1,8 +1,12 @@
 package app
 
 import (
+	"context"
+	"os"
+
 	"github.com/blackhorseya/ekko/adapter/cli/app/config"
 	"github.com/blackhorseya/ekko/adapter/cli/app/version"
+	configx "github.com/blackhorseya/ekko/internal/pkg/config"
 	"github.com/blackhorseya/ekko/pkg/adapters"
 	"github.com/spf13/cobra"
 )
@@ -23,6 +27,17 @@ func NewCmd() adapters.CLI {
 
 	rootCmd.AddCommand(version.NewVersionCmd())
 	rootCmd.AddCommand(config.NewConfigCmd())
+
+	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		if path == "" {
+			path = os.Getenv("HOME") + "/.ekko/config.yaml"
+		}
+
+		cfg, err := configx.NewWithPath(path)
+		cobra.CheckErr(err)
+
+		cmd.SetContext(context.WithValue(cmd.Context(), "config", cfg))
+	}
 
 	return &cmd{
 		rootCmd: rootCmd,

--- a/adapter/cli/app/config/config.go
+++ b/adapter/cli/app/config/config.go
@@ -6,19 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Options is used to define config cmd options
-type Options struct {
-}
-
-// NewOptions is used to create a new Options instance
-func NewOptions() *Options {
-	return &Options{}
-}
-
 // NewConfigCmd is used to create config command
 func NewConfigCmd() *cobra.Command {
-	o := NewOptions()
-
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "config is used to manage ekko config",
@@ -28,15 +17,11 @@ func NewConfigCmd() *cobra.Command {
 		Use:   "show",
 		Short: "show is used to show ekko config",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return o.Show()
+			fmt.Println("not implemented yet")
+
+			return nil
 		},
 	})
 
 	return cmd
-}
-
-func (o *Options) Show() error {
-	fmt.Println("not implement yet")
-
-	return nil
 }

--- a/adapter/cli/app/config/config.go
+++ b/adapter/cli/app/config/config.go
@@ -6,8 +6,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Options is used to define config cmd options
+type Options struct {
+}
+
+// NewOptions is used to create a new Options instance
+func NewOptions() *Options {
+	return &Options{}
+}
+
 // NewConfigCmd is used to create config command
 func NewConfigCmd() *cobra.Command {
+	o := NewOptions()
+
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "config is used to manage ekko config",
@@ -16,10 +27,16 @@ func NewConfigCmd() *cobra.Command {
 	cmd.AddCommand(&cobra.Command{
 		Use:   "show",
 		Short: "show is used to show ekko config",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("show config")
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return o.Show()
 		},
 	})
 
 	return cmd
+}
+
+func (o *Options) Show() error {
+	fmt.Println("not implement yet")
+
+	return nil
 }

--- a/adapter/cli/app/config/config.go
+++ b/adapter/cli/app/config/config.go
@@ -1,8 +1,11 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 
+	"github.com/blackhorseya/ekko/internal/pkg/config"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -17,7 +20,15 @@ func NewConfigCmd() *cobra.Command {
 		Use:   "show",
 		Short: "show is used to show ekko config",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println("not implemented yet")
+			cfg, ok := cmd.Context().Value("config").(*config.Config)
+			if !ok {
+				return errors.New("failed to get config")
+			}
+
+			bytes, err := json.MarshalIndent(cfg, "", "  ")
+			cobra.CheckErr(err)
+
+			fmt.Println(string(bytes))
 
 			return nil
 		},

--- a/adapter/cli/app/version/version.go
+++ b/adapter/cli/app/version/version.go
@@ -6,30 +6,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Options is used to define version cmd options
-type Options struct {
-}
-
-// NewOptions is used to create a new Options instance
-func NewOptions() *Options {
-	return &Options{}
-}
-
 // NewVersionCmd is used to create a new version cmd instance
 func NewVersionCmd() *cobra.Command {
-	o := NewOptions()
-
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print the version number of ekko",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return o.Run()
+			fmt.Println("ekko version 0.0.1")
+
+			return nil
 		},
 	}
-}
-
-func (o *Options) Run() error {
-	fmt.Println("ekko version 0.0.1")
-
-	return nil
 }

--- a/adapter/cli/app/version/version.go
+++ b/adapter/cli/app/version/version.go
@@ -6,13 +6,30 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Options is used to define version cmd options
+type Options struct {
+}
+
+// NewOptions is used to create a new Options instance
+func NewOptions() *Options {
+	return &Options{}
+}
+
 // NewVersionCmd is used to create a new version cmd instance
 func NewVersionCmd() *cobra.Command {
+	o := NewOptions()
+
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print the version number of ekko",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("ekko version: v0.0.1")
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return o.Run()
 		},
 	}
+}
+
+func (o *Options) Run() error {
+	fmt.Println("ekko version 0.0.1")
+
+	return nil
 }

--- a/adapter/cli/main.go
+++ b/adapter/cli/main.go
@@ -1,28 +1,11 @@
 package main
 
 import (
-	"flag"
 	"log"
-	"os"
 )
 
-var path = flag.String("c", "", "path to config file (default: $HOME/.ekko/config.yaml)")
-
-func init() {
-	flag.Parse()
-
-	if *path == "" {
-		*path = os.Getenv("HOME") + "/.ekko/config.yaml"
-	}
-}
-
 func main() {
-	config, err := NewConfig(*path)
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	cmd, err := NewCmd(config)
+	cmd, err := NewCmd()
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/adapter/cli/wire.go
+++ b/adapter/cli/wire.go
@@ -6,15 +6,10 @@ package main
 
 import (
 	"github.com/blackhorseya/ekko/adapter/cli/app"
-	"github.com/blackhorseya/ekko/internal/pkg/config"
 	"github.com/blackhorseya/ekko/pkg/adapters"
 	"github.com/google/wire"
 )
 
-func NewConfig(path string) (*config.Config, error) {
-	panic(wire.Build(config.NewWithPath))
-}
-
-func NewCmd(config *config.Config) (adapters.CLI, error) {
+func NewCmd() (adapters.CLI, error) {
 	panic(wire.Build(app.NewCmd))
 }

--- a/adapter/cli/wire_gen.go
+++ b/adapter/cli/wire_gen.go
@@ -8,21 +8,12 @@ package main
 
 import (
 	"github.com/blackhorseya/ekko/adapter/cli/app"
-	"github.com/blackhorseya/ekko/internal/pkg/config"
 	"github.com/blackhorseya/ekko/pkg/adapters"
 )
 
 // Injectors from wire.go:
 
-func NewConfig(path2 string) (*config.Config, error) {
-	configConfig, err := config.NewWithPath(path2)
-	if err != nil {
-		return nil, err
-	}
-	return configConfig, nil
-}
-
-func NewCmd(config2 *config.Config) (adapters.CLI, error) {
+func NewCmd() (adapters.CLI, error) {
 	cli := app.NewCmd()
 	return cli, nil
 }


### PR DESCRIPTION
- Remove unused imports and variables from `adapter/cli/main.go`
- Remove the `NewConfig` function and related imports from `adapter/cli/wire.go`
- Remove the `NewConfig` function and related imports from `adapter/cli/wire_gen.go`
- Update the `NewCmd` function in `adapter/cli/wire.go` and `adapter/cli/wire_gen.go`